### PR TITLE
123SmartBms communication over usb

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,6 +41,8 @@ qt_add_library(device SHARED
     serialdevices/atmega.cpp
     serialdevices/victronenergy.h
     serialdevices/victronenergy.cpp
+    serialdevices/bms123electric.h
+    serialdevices/bms123electric.cpp
 )
 
 target_link_libraries(device Qt6::Core)

--- a/inputdevicemanager.cpp
+++ b/inputdevicemanager.cpp
@@ -7,6 +7,7 @@
 #include "serialportsettings.h"
 #include "serialdevices/victronenergy.h"
 #include "serialdevices/atmega.h"
+#include "serialdevices/bms123electric.h"
 
 
 
@@ -139,6 +140,14 @@ void InputDeviceManager::connectInputDevice(QString aDeviceName)
         ve->openDevice(settings);
         mConnectedInputDevices[aDeviceName] = ve;
         emit inputDeviceConnected(aDeviceName);
+    }
+    else if(manufacturer.contains("123electric"))
+    {
+        BMS123electric *bms = new BMS123electric();
+        bms->openDevice(settings);
+        mConnectedInputDevices[aDeviceName] = bms;
+        emit inputDeviceAvailable(aDeviceName);
+
     }
     else
     {

--- a/serialdevices/bms123electric.cpp
+++ b/serialdevices/bms123electric.cpp
@@ -1,0 +1,151 @@
+#include "bms123electric.h"
+
+#include <tagsystem/tag.h>
+#include <tagsystem/taglist.h>
+
+#include <QDebug>
+
+#include <QBitArray>
+#include <bitset>
+
+union convert
+{
+    int i;
+    uint8_t buffer[4];
+};
+
+BMS123electric::BMS123electric(QObject *parent) :
+    Device(parent)
+{
+    totalVoltageTag_ = TagList::sGetInstance().createTag(deviceName_, "total_voltage", Tag::eDouble, 0.0, "Totale voltage of battery");
+
+    statusTags_.allowToCharge = TagList::sGetInstance().createTag(deviceName_, "allow_to_charge", Tag::eBool, true, "Allow to charge battery");
+    statusTags_.allowToDischarge = TagList::sGetInstance().createTag(deviceName_, "allow_to_discharge", Tag::eBool, true, "Allow to discharge battery");
+    statusTags_.commError = TagList::sGetInstance().createTag(deviceName_, "comm_error", Tag::eBool, false, "Communication error");
+    statusTags_.exceedVmin = TagList::sGetInstance().createTag(deviceName_, "exceed_v_min", Tag::eBool, false, "Exceed min voltage");
+    statusTags_.exceedVmax = TagList::sGetInstance().createTag(deviceName_, "exceed_v_max", Tag::eBool, false, "Exceed max voltage");
+    statusTags_.exceedTmin = TagList::sGetInstance().createTag(deviceName_, "exceed_t_min", Tag::eBool, false, "Exceed min temperature");
+    statusTags_.exceedTmax = TagList::sGetInstance().createTag(deviceName_, "exceed_t_max", Tag::eBool, false, "Exceed max temperature");
+    statusTags_.socNotCalibrated = TagList::sGetInstance().createTag(deviceName_, "soc_not_calibrated", Tag::eBool, false, "soc not calibrated");
+
+    // cells are created on demand to allow use for different batteries.
+}
+
+void BMS123electric::dataRead(QByteArray data)
+{
+    frame_.append(data);
+    if(frame_.size() == 58)
+    {
+        // process data...
+        processFrame();
+        frame_.clear();
+    }
+    else if(frame_.size() > 58)
+    {
+        qDebug() << "Error deleting frame";
+        frame_.clear();
+    }
+}
+
+int BMS123electric::getPid() const
+{
+    return 37;
+}
+
+void BMS123electric::processFrame()
+{
+    if(!isChecksumValid())
+        return;
+
+    readTotalVoltage();
+    auto currentCell = readCurrentCell();
+
+    readCellVoltage(currentCell);
+    readCellTemperature(currentCell);
+    readStatusByte1();
+}
+
+bool BMS123electric::isChecksumValid()
+{
+    int checksum = (uint8_t)frame_.at(57);
+    int sum = 0;
+    for(int i= 0; i<57; ++i)
+        sum += (uint8_t)frame_.at(i);
+    int low = sum & 0xFF;
+
+    return checksum == low;
+}
+
+double BMS123electric::readTotalVoltage()
+{
+    QString hex(frame_.mid(0, 3).toHex());
+    bool v;
+    double val = hex.toInt(&v, 16) * 0.005;
+
+    totalVoltageTag_->setValue(val);
+
+    return val;
+}
+
+int BMS123electric::readCurrentCell()
+{
+    QString hex(frame_.mid(24, 1).toHex());
+    bool v;
+    int val = hex.toInt(&v, 16);
+    return val;
+}
+
+double BMS123electric::readCellVoltage(int cell)
+{
+    QString hex(frame_.mid(26, 2).toHex());
+    bool v;
+    double val = hex.toInt(&v, 16) * 0.005;
+
+    if(!cellTags_.contains(cell))
+    {
+        cellTags tags;
+        tags.voltage = TagList::sGetInstance().createTag(deviceName_, QString("cell_%1_voltage").arg(cell), Tag::eDouble, 0.0, QString("cell %1 voltage").arg(cell));
+        tags.temperature = TagList::sGetInstance().createTag(deviceName_, QString("cell_%1_temperature").arg(cell), Tag::eInt, 0, QString("cell %1 temperature").arg(cell));
+        cellTags_[cell] = tags;
+    }
+
+    cellTags_[cell].voltage->setValue(val);
+
+    return val;
+}
+
+int BMS123electric::readCellTemperature(int cell)
+{
+    QString hex(frame_.mid(28, 2).toHex());
+    bool v;
+    int val = hex.toInt(&v, 16) - 276;
+
+    if(!cellTags_.contains(cell))
+    {
+        cellTags tags;
+        tags.voltage = TagList::sGetInstance().createTag(deviceName_, QString("cell_%1_voltage").arg(cell), Tag::eDouble, 0.0, QString("cell %1 voltage").arg(cell));
+        tags.temperature = TagList::sGetInstance().createTag(deviceName_, QString("cell_%1_temperature").arg(cell), Tag::eInt, 0, QString("cell %1 temperature").arg(cell));
+        cellTags_[cell] = tags;
+    }
+
+    cellTags_[cell].temperature->setValue(val);
+
+    return val;
+}
+
+void BMS123electric::readStatusByte1()
+{
+    auto status = (uint8_t)frame_.at(30);
+    auto n = QString::number(status, 16).toInt();
+
+    std::bitset<8> bitset(n);
+
+    statusTags_.allowToCharge->setValue(bitset[0]);
+    statusTags_.allowToDischarge->setValue(bitset[1]);
+    statusTags_.commError->setValue(bitset[2]);
+    statusTags_.exceedVmin->setValue(bitset[3]);
+    statusTags_.exceedVmax->setValue(bitset[4]);
+    statusTags_.exceedTmin->setValue(bitset[5]);
+    statusTags_.exceedTmax->setValue(bitset[6]);
+    statusTags_.socNotCalibrated->setValue(bitset[7]);
+}

--- a/serialdevices/bms123electric.h
+++ b/serialdevices/bms123electric.h
@@ -1,0 +1,53 @@
+#ifndef BMS123ELECTRIC_H
+#define BMS123ELECTRIC_H
+
+#include <QObject>
+
+#include "../device.h"
+#include <map>
+
+class Tag;
+
+class BMS123electric : public Device
+{
+    Q_OBJECT
+public:
+    BMS123electric(QObject *parent = nullptr);
+
+    void dataRead(QByteArray data) override;
+    int getPid() const override;
+
+private:
+    const QString deviceName_{"123SmartBms"};
+    struct cellTags
+    {
+        Tag* voltage = nullptr;
+        Tag* temperature = nullptr;
+    };
+    struct Status{
+        Tag* allowToCharge = nullptr;
+        Tag* allowToDischarge = nullptr;
+        Tag* commError = nullptr;
+        Tag* exceedVmin = nullptr;
+        Tag* exceedVmax = nullptr;
+        Tag* exceedTmin = nullptr;
+        Tag* exceedTmax = nullptr;
+        Tag* socNotCalibrated = nullptr;
+    };
+
+    void processFrame();
+    bool isChecksumValid();
+    QByteArray frame_;
+
+    double readTotalVoltage();
+    int readCurrentCell();
+    double readCellVoltage(int cell);
+    int readCellTemperature(int cell);
+    void readStatusByte1(); ///< alarms
+
+    std::map<int, cellTags> cellTags_;
+    Tag* totalVoltageTag_;
+    Status statusTags_;
+};
+
+#endif // BMS123ELECTRIC_H


### PR DESCRIPTION
Read values from the 123SmartBms over its usb, with its original usb cable. The usb adapter has vendor id to use for verification when connected.
Some of the values are translated and made available on an instance of the juneserver, with corresponding tags.